### PR TITLE
Make HTTP body length tunable at runtime via APP_HTTP_MAX_BODY_LENGTH

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -10,6 +10,11 @@ import Config
 config :lynx,
   ecto_repos: [Lynx.Repo]
 
+# Initialize endpoint plugs at runtime so options sourced from
+# config/runtime.exs (e.g. http_max_body_length) take effect without
+# rebuilding the release.
+config :phoenix, :plug_init_mode, :runtime
+
 # Configures the endpoint
 config :lynx, LynxWeb.Endpoint,
   url: [host: System.get_env("APP_HOST") || "localhost"],

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -24,6 +24,11 @@ if System.get_env("PHX_SERVER") do
   config :lynx, LynxWeb.Endpoint, server: true
 end
 
+if max_body_length = System.get_env("APP_HTTP_MAX_BODY_LENGTH") do
+  config :lynx, LynxWeb.Endpoint,
+    http_max_body_length: String.to_integer(max_body_length)
+end
+
 if config_env() == :prod do
   maybe_ipv6 = if System.get_env("ECTO_IPV6"), do: [:inet6], else: []
 

--- a/lib/lynx/config.ex
+++ b/lib/lynx/config.ex
@@ -1,0 +1,19 @@
+defmodule Lynx.Config do
+  @moduledoc """
+  Runtime configuration helpers for the Lynx application.
+  """
+
+  @default_max_body_length 8_000_000
+
+  @doc """
+  Returns the configured HTTP request body size limit (in bytes).
+
+  Reads `:http_max_body_length` from the `LynxWeb.Endpoint` application
+  environment so the value can be overridden at runtime via
+  `APP_HTTP_MAX_BODY_LENGTH` (see `config/runtime.exs`).
+  """
+  def max_body_length do
+    Application.get_env(:lynx, LynxWeb.Endpoint, [])[:http_max_body_length] ||
+      @default_max_body_length
+  end
+end

--- a/lib/lynx_web/endpoint.ex
+++ b/lib/lynx_web/endpoint.ex
@@ -5,12 +5,6 @@
 defmodule LynxWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :lynx
 
-  @max_body_length Application.compile_env(
-                     :lynx,
-                     [__MODULE__, :http_max_body_length],
-                     8_000_000
-                   )
-
   # The session will be stored in the cookie and signed,
   # this means its contents can be read but not tampered with.
   # Set :encryption_salt if you would also like to encrypt it.
@@ -54,10 +48,9 @@ defmodule LynxWeb.Endpoint do
 
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
 
-  plug Plug.Parsers,
+  plug LynxWeb.Plug.RuntimeParsers,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
-    length: @max_body_length,
     json_decoder: Phoenix.json_library()
 
   plug Plug.MethodOverride

--- a/lib/lynx_web/plug/runtime_parsers.ex
+++ b/lib/lynx_web/plug/runtime_parsers.ex
@@ -1,0 +1,21 @@
+defmodule LynxWeb.Plug.RuntimeParsers do
+  @moduledoc """
+  Thin wrapper around `Plug.Parsers` that resolves the body length limit
+  at endpoint boot from the application environment, not at compile time.
+
+  This is only effective when `config :phoenix, :plug_init_mode, :runtime`
+  is set, so endpoint plug `init/1` callbacks run after `runtime.exs`.
+  """
+
+  @behaviour Plug
+
+  @impl true
+  def init(opts) do
+    opts
+    |> Keyword.put(:length, Lynx.Config.max_body_length())
+    |> Plug.Parsers.init()
+  end
+
+  @impl true
+  defdelegate call(conn, opts), to: Plug.Parsers
+end

--- a/test/lynx_web/endpoint_test.exs
+++ b/test/lynx_web/endpoint_test.exs
@@ -3,11 +3,45 @@
 # license that can be found in the LICENSE file.
 
 defmodule LynxWeb.EndpointTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
+
+  alias Lynx.Config
 
   describe ":http_max_body_length endpoint config" do
     test "defaults to 8 MB so existing deployments are unaffected" do
       assert Application.get_env(:lynx, LynxWeb.Endpoint)[:http_max_body_length] == 8_000_000
+    end
+
+    test "Lynx.Config.max_body_length/0 reads from app env at runtime" do
+      original = Application.get_env(:lynx, LynxWeb.Endpoint)
+
+      try do
+        Application.put_env(
+          :lynx,
+          LynxWeb.Endpoint,
+          Keyword.put(original, :http_max_body_length, 12_345)
+        )
+
+        assert Config.max_body_length() == 12_345
+      after
+        Application.put_env(:lynx, LynxWeb.Endpoint, original)
+      end
+    end
+
+    test "Lynx.Config.max_body_length/0 falls back to 8 MB when unset" do
+      original = Application.get_env(:lynx, LynxWeb.Endpoint)
+
+      try do
+        Application.put_env(
+          :lynx,
+          LynxWeb.Endpoint,
+          Keyword.delete(original, :http_max_body_length)
+        )
+
+        assert Config.max_body_length() == 8_000_000
+      after
+        Application.put_env(:lynx, LynxWeb.Endpoint, original)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Follow-up to #265. The existing `APP_HTTP_MAX_BODY_LENGTH` env var is read via `Application.compile_env`, so it only takes effect at build time — flipping it on a running release has no impact. This PR makes it actually runtime-tunable, so operators can resize the limit by restarting the container with a different env value (no rebuild).

## What changed

- New `Lynx.Config.max_body_length/0` reads `:http_max_body_length` from app env with an 8 MB fallback.
- New `LynxWeb.Plug.RuntimeParsers` wraps `Plug.Parsers` and resolves `length` inside its own `init/1` (so the value is fetched after `runtime.exs` runs).
- Endpoint now uses the wrapper instead of `Plug.Parsers` directly; the `@max_body_length` module attribute is gone.
- `config :phoenix, :plug_init_mode, :runtime` so endpoint plug `init/1` callbacks run at endpoint boot rather than at module compile.
- `config/runtime.exs` reads `APP_HTTP_MAX_BODY_LENGTH` and writes it into the endpoint config.
- Default behavior unchanged: 8 MB when the env var is unset.

## PoW
The state file is uploaded successfully. Dummy lock ID is used so Bad Request is expected.
- Environment variable is set to 50MiB
- Default value is 8MiB
- Dummy test file is 15MiB (should be failed if 8MiB is used for the configuration).

```sh
curl -v -X POST \
  -u "$USERNAME:$PASSWORD" \
  -H "Content-Type: application/json" \
  --data-binary @/tmp/15mb.bin \
  "https://${DOMAIN}/client/***/***/dev/state?ID=00000000-0000-0000-0000-000000000000"
....
* upload completely sent off: 15728640 bytes
...
<
Bad Request%
```